### PR TITLE
[feat] Add Secret Creation Logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.0.1
+VERSION ?= dev
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 # Options for 'bundle-build'
@@ -59,6 +59,9 @@ deploy: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${MANAGER_IMG}
 	cd config/notifier && $(KUSTOMIZE) edit set image notifier=${NOTIFIER_IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
+
+undeploy: kustomize
+	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/api/v1alpha1/notification_types.go
+++ b/api/v1alpha1/notification_types.go
@@ -34,6 +34,7 @@ const (
 
 type EmailNotification struct {
 	SMTPConfig string `json:"smtpcfg"`
+	SMTPSecret string `json:"smtpsecret"`
 	From       string `json:"from"`
 	To         string `json:"to"`
 	Cc         string `json:"cc,omitempty"`
@@ -47,9 +48,9 @@ type WebhookNotification struct {
 }
 
 type SlackNotification struct {
-	Authorization       string `json:"authorization"`
-	Channel             string `json:"channel"`
-	Text                string `json:"text"`
+	Authorization string `json:"authorization"`
+	Channel       string `json:"channel"`
+	Text          string `json:"text"`
 }
 
 // NotificationSpec defines the desired state of Notification
@@ -71,7 +72,6 @@ type NotificationStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	Type     NotificationType `json:"type,omitempty"`
 	EndPoint string           `json:"endpoint,omitempty"`
-	ApiKey   string           `json:"apikey,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/alarm.tmax.io_notifications.yaml
+++ b/config/crd/bases/alarm.tmax.io_notifications.yaml
@@ -55,6 +55,8 @@ spec:
                   type: string
                 smtpcfg:
                   type: string
+                smtpsecret:
+                  type: string
                 subject:
                   type: string
                 to:
@@ -63,6 +65,7 @@ spec:
               - body
               - from
               - smtpcfg
+              - smtpsecret
               - subject
               - to
               type: object
@@ -93,8 +96,6 @@ spec:
         status:
           description: NotificationStatus defines the observed state of Notification
           properties:
-            apikey:
-              type: string
             endpoint:
               type: string
             type:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: changjjjjjjjj/alarm-operator
-  newTag: 0.0.1
+  newName: tmaxcloudck/alarm-operator
+  newTag: dev

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,21 +23,21 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - command:
-        - /manager
-        args:
-        - --enable-leader-election
-        image: controller:latest
-        imagePullPolicy: Always
-        name: manager
-        env:
-        - name: NOTIFIER_URL
-          value: http://$(NOTIFIER_SVC_NAME):8080
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
+        - command:
+            - /manager
+          args:
+            - --enable-leader-election
+          image: controller:latest
+          imagePullPolicy: Always
+          name: manager
+          env:
+            - name: NOTIFIER_URL
+              value: http://$(NOTIFIER_SVC_NAME):8080
+          resources:
+            limits:
+              cpu: 100m
+              memory: 30Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
       terminationGracePeriodSeconds: 10

--- a/config/notifier/kustomization.yaml
+++ b/config/notifier/kustomization.yaml
@@ -5,5 +5,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: notifier
-  newName: changjjjjjjjj/notifier
-  newTag: 0.0.1
+  newName: tmaxcloudck/notifier
+  newTag: dev

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -95,8 +95,10 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/config/samples/email_notification.yaml
+++ b/config/samples/email_notification.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   email:
     smtpcfg: smtpconfig-sample
+    smtpsecret: tmaxcloud-announcer-credit
     from: no_reply@tmax.co.kr
     to: all@tmax.co.kr
     subject: "[INFO] Notification from alarm-operator"

--- a/config/samples/smtpconfig.yaml
+++ b/config/samples/smtpconfig.yaml
@@ -5,5 +5,3 @@ metadata:
 data:
   host: "smtp.gmail.com"
   port: "587"
-  username: "noreply@tmaxcloud.io"
-  password: "enter_your_password"

--- a/pkg/notification/notification.go
+++ b/pkg/notification/notification.go
@@ -31,11 +31,11 @@ type WebhookNotification struct {
 }
 
 type SlackNotification struct {
-	Authorization       string `json:"authorization"`
+	Authorization string `json:"authorization"`
 	SlackMessage
 }
 
 type SlackMessage struct {
-	Channel             string `json:"channel"`
-	Text                string `json:"text"`
+	Channel string `json:"channel"`
+	Text    string `json:"text"`
 }

--- a/pkg/notification/registry.go
+++ b/pkg/notification/registry.go
@@ -32,7 +32,7 @@ func (r *NotificationRegistry) Register(id string, key string, noti Notification
 	default:
 		return fmt.Errorf(fmt.Sprintf("unsupported notification type: %s\n", reflect.TypeOf(noti)))
 	}
-	
+
 	return r.ds.Save(id, payload)
 }
 
@@ -41,7 +41,7 @@ func (r *NotificationRegistry) Fetch(id string) (string, Notification, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	
+
 	// FIXME: too bad extraction
 	tokens := strings.Split(string(data), ":")
 	notiType := tokens[0]

--- a/pkg/notifier/job/notification_job.go
+++ b/pkg/notifier/job/notification_job.go
@@ -75,8 +75,8 @@ func (n *SlackNotificationJob) Execute(job interface{}) error {
 	req.Header.Add("Authorization", n.noti.Authorization)
 
 	tr := &http.Transport{
-        TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-    }
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
 	client := &http.Client{Transport: tr}
 	resp, err := client.Do(req)
 


### PR DESCRIPTION
- API Keys of notifications are stored in secrets
- Do not store API key in NotificationStaus
- Store smtp user data in secrets
- Removed ingress client creation in notification controller
- Refactored notifications' body to be changed by header